### PR TITLE
consistently require-import all_ssreflect instead of pieces of it

### DIFF
--- a/src/adt.v
+++ b/src/adt.v
@@ -1,5 +1,4 @@
-From Coq Require Import ssreflect ssrbool ssrfun.
-From mathcomp Require Import eqtype order seq path.
+From mathcomp Require Import all_ssreflect.
 From favssr Require Import bintree bst.
 
 Set Implicit Arguments.

--- a/src/avl.v
+++ b/src/avl.v
@@ -1,6 +1,5 @@
 From Equations Require Import Equations.
-From Coq Require Import ssreflect ssrbool ssrfun.
-From mathcomp Require Import eqtype ssrnat ssrint ssralg ssrnum order seq path.
+From mathcomp Require Import all_ssreflect ssrint ssralg ssrnum.
 From favssr Require Import prelude bintree bst adt.
 Set Implicit Arguments.
 Unset Strict Implicit.

--- a/src/basics.v
+++ b/src/basics.v
@@ -1,6 +1,5 @@
 From Equations Require Import Equations.
-From Coq Require Import ssreflect ssrbool ssrfun.
-From mathcomp Require Import ssrnat eqtype seq div.
+From mathcomp Require Import all_ssreflect.
 From favssr Require Import prelude.
 Set Implicit Arguments.
 Unset Strict Implicit.

--- a/src/beyond.v
+++ b/src/beyond.v
@@ -1,6 +1,5 @@
 From Equations Require Import Equations.
-From Coq Require Import ssreflect ssrbool ssrfun.
-From mathcomp Require Import ssrnat eqtype order seq path.
+From mathcomp Require Import all_ssreflect.
 From favssr Require Import prelude bintree bst adt redblack.
 
 Set Implicit Arguments.

--- a/src/binom_heap.v
+++ b/src/binom_heap.v
@@ -1,5 +1,4 @@
-From Coq Require Import ssreflect ssrbool ssrfun.
-From mathcomp Require Import ssrnat eqtype order seq path bigop prime binomial.
+From mathcomp Require Import all_ssreflect.
 From favssr Require Import prelude basics priority.
 
 Set Implicit Arguments.

--- a/src/bintree.v
+++ b/src/bintree.v
@@ -1,6 +1,5 @@
 From Equations Require Import Equations.
-From Coq Require Import ssreflect ssrbool ssrfun.
-From mathcomp Require Import eqtype ssrnat seq prime.
+From mathcomp Require Import all_ssreflect.
 From favssr Require Import prelude.
 Set Implicit Arguments.
 Unset Strict Implicit.

--- a/src/braun.v
+++ b/src/braun.v
@@ -1,6 +1,5 @@
 From Equations Require Import Equations.
-From Coq Require Import ssreflect ssrbool ssrfun.
-From mathcomp Require Import eqtype ssrnat seq prime bigop ssrAC.
+From mathcomp Require Import all_ssreflect.
 From favssr Require Import prelude bintree.
 
 Set Implicit Arguments.

--- a/src/braun_queue.v
+++ b/src/braun_queue.v
@@ -1,6 +1,5 @@
 From Equations Require Import Equations.
-From Coq Require Import ssreflect ssrbool ssrfun.
-From mathcomp Require Import ssrnat eqtype order seq.
+From mathcomp Require Import all_ssreflect.
 From favssr Require Import prelude bintree braun priority.
 
 Set Implicit Arguments.

--- a/src/bst.v
+++ b/src/bst.v
@@ -1,6 +1,5 @@
 From Equations Require Import Equations.
-From Coq Require Import ssreflect ssrbool ssrfun.
-From mathcomp Require Import eqtype choice ssrnat seq order path.
+From mathcomp Require Import all_ssreflect.
 From favssr Require Import prelude bintree.
 Set Implicit Arguments.
 Unset Strict Implicit.

--- a/src/huffman.v
+++ b/src/huffman.v
@@ -1,6 +1,5 @@
 From Equations Require Import Equations.
-From Coq Require Import ssreflect ssrbool ssrfun.
-From mathcomp Require Import eqtype ssrnat seq bigop ssrAC.
+From mathcomp Require Import all_ssreflect.
 From favssr Require Import prelude.
 
 Set Implicit Arguments.

--- a/src/leftist.v
+++ b/src/leftist.v
@@ -1,5 +1,4 @@
-From Coq Require Import ssreflect ssrbool ssrfun.
-From mathcomp Require Import ssrnat eqtype order seq path prime.
+From mathcomp Require Import all_ssreflect.
 From favssr Require Import prelude bintree priority.
 
 Set Implicit Arguments.

--- a/src/prelude.v
+++ b/src/prelude.v
@@ -1,5 +1,4 @@
-From Coq Require Import ssreflect ssrbool ssrfun.
-From mathcomp Require Import ssrnat eqtype seq order path prime div.
+From mathcomp Require Import all_ssreflect.
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/src/priority.v
+++ b/src/priority.v
@@ -1,5 +1,4 @@
-From Coq Require Import ssreflect ssrbool ssrfun.
-From mathcomp Require Import eqtype order seq path.
+From mathcomp Require Import all_ssreflect.
 From favssr Require Import prelude bintree.
 
 Set Implicit Arguments.

--- a/src/quadtree.v
+++ b/src/quadtree.v
@@ -1,6 +1,5 @@
 From Equations Require Import Equations.
-From Coq Require Import ssreflect ssrbool ssrfun.
-From mathcomp Require Import eqtype choice ssrnat div bigop ssrAC seq ssralg.
+From mathcomp Require Import all_ssreflect ssralg.
 From favssr Require Import prelude.
 Set Implicit Arguments.
 Unset Strict Implicit.

--- a/src/redblack.v
+++ b/src/redblack.v
@@ -1,6 +1,5 @@
 From Equations Require Import Equations.
-From Coq Require Import ssreflect ssrbool ssrfun.
-From mathcomp Require Import eqtype ssrnat prime order seq path.
+From mathcomp Require Import all_ssreflect.
 From favssr Require Import prelude bintree bst adt.
 Set Implicit Arguments.
 Unset Strict Implicit.

--- a/src/selection.v
+++ b/src/selection.v
@@ -1,6 +1,5 @@
 From Equations Require Import Equations.
-From Coq Require Import ssreflect ssrbool ssrfun.
-From mathcomp Require Import ssrnat eqtype seq path order bigop div ssrnum ssralg ssrint prime.
+From mathcomp Require Import all_ssreflect ssralg ssrnum ssrint.
 From favssr Require Import prelude sorting.
 Set Implicit Arguments.
 Unset Strict Implicit.

--- a/src/sorting.v
+++ b/src/sorting.v
@@ -1,6 +1,5 @@
 From Equations Require Import Equations.
-From Coq Require Import ssreflect ssrbool ssrfun.
-From mathcomp Require Import ssrnat eqtype seq path order bigop prime.
+From mathcomp Require Import all_ssreflect.
 From favssr Require Import prelude.
 Set Implicit Arguments.
 Unset Strict Implicit.

--- a/src/trie.v
+++ b/src/trie.v
@@ -1,6 +1,5 @@
 From Equations Require Import Equations.
-From Coq Require Import ssreflect ssrbool ssrfun.
-From mathcomp Require Import eqtype ssrnat seq.
+From mathcomp Require Import all_ssreflect.
 From favssr Require Import prelude bintree adt.
 
 Set Implicit Arguments.

--- a/src/twothree.v
+++ b/src/twothree.v
@@ -1,6 +1,5 @@
 From Equations Require Import Equations.
-From Coq Require Import ssreflect ssrbool ssrfun.
-From mathcomp Require Import ssrnat eqtype order seq path.
+From mathcomp Require Import all_ssreflect.
 From favssr Require Import prelude bst adt.
 
 Set Implicit Arguments.


### PR DESCRIPTION
Coq's stdlib will soon be reorganized, not least due to renaming of Coq. To avoid problems with this, how about only depending on `mathcomp`? This is likely to be a lot more future-proof.